### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dreadlord.visualstudio.com/c22315b4-428e-4055-9d93-79b7dc933006/34931e71-6712-4e86-9b55-1b80de6f9ad8/_apis/work/boardbadge/07bce17e-de40-473f-a8e6-34257ed30d7c)](https://dreadlord.visualstudio.com/c22315b4-428e-4055-9d93-79b7dc933006/_boards/board/t/34931e71-6712-4e86-9b55-1b80de6f9ad8/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#3](https://dreadlord.visualstudio.com/c22315b4-428e-4055-9d93-79b7dc933006/_workitems/edit/3). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.